### PR TITLE
fix: time range 유틸 함수 오류 수정

### DIFF
--- a/app/(main)/schedule/utils/scheduleUtils.test.ts
+++ b/app/(main)/schedule/utils/scheduleUtils.test.ts
@@ -29,4 +29,14 @@ describe("createTimeRangeList()", () => {
       ["10:20", "11:00"],
     ]);
   });
+
+  test("should return an array of time ranges from PM to AM", () => {
+    const result = createTimeRangeList("23:00", "01:00");
+    expect(result).toEqual([
+      ["23:00", "23:30"],
+      ["23:30", "00:00"],
+      ["00:00", "00:30"],
+      ["00:30", "01:00"],
+    ]);
+  });
 });

--- a/app/(main)/schedule/utils/scheduleUtils.ts
+++ b/app/(main)/schedule/utils/scheduleUtils.ts
@@ -18,9 +18,13 @@ export const createTimeRangeList = (start: string, end: string, GAP = 30) => {
   const startTime = startHH * 60 + startMM;
   const endTime = endHH * 60 + endMM;
 
-  return new Array(Math.floor((endTime - startTime) / GAP)).fill(startTime).map((startTime, i) => {
-    const prevTime = startTime + i * GAP;
-    const nextTime = startTime + (i + 1) * GAP;
+  const MINUTES_PER_DAY = 24 * 60;
+  const MinutesDiff =
+    startTime < endTime ? endTime - startTime : endTime + (MINUTES_PER_DAY - startTime);
+
+  return new Array(Math.floor(MinutesDiff / GAP)).fill(startTime).map((startTime, i) => {
+    const prevTime = (startTime + i * GAP) % MINUTES_PER_DAY;
+    const nextTime = (startTime + (i + 1) * GAP) % MINUTES_PER_DAY;
 
     const prevHH = Math.floor(prevTime / 60)
       .toString()


### PR DESCRIPTION
- 종료 시간이 시작 시간보다 작은 경우 (ex. "23:00" ~"01:00") 배열 생성시 음수가 전달되어 Invalid array length 오류 발생
- 해당 케이스를 처리하는 계산 로직 추가