### PR TITLE
refactor: DatePicker 기본 날짜, 선택 범위 제한 추가 및 디자인 변경사항 반영

### DIFF
--- a/components/DatePicker/DatePicker.stories.tsx
+++ b/components/DatePicker/DatePicker.stories.tsx
@@ -3,6 +3,9 @@ import { DatePicker } from "./DatePicker";
 
 const meta: Meta<typeof DatePicker> = {
   component: DatePicker,
+  parameters: {
+    backgrounds: { default: "dark" },
+  },
 };
 
 export default meta;

--- a/components/DatePicker/DatePicker.stories.tsx
+++ b/components/DatePicker/DatePicker.stories.tsx
@@ -6,17 +6,27 @@ const meta: Meta<typeof DatePicker> = {
   parameters: {
     backgrounds: { default: "dark" },
   },
+  argTypes: {
+    defaultDate: {
+      control: "date",
+    },
+    minDate: {
+      control: "date",
+    },
+    maxDate: {
+      control: "date",
+    },
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof DatePicker>;
 
 export const Primary: Story = {
-  args: {},
-  render: () => {
+  render: (args) => {
     return (
       <div className="h-40">
-        <DatePicker />
+        <DatePicker {...args} />
       </div>
     );
   },

--- a/components/DatePicker/DatePicker.tsx
+++ b/components/DatePicker/DatePicker.tsx
@@ -1,31 +1,31 @@
-import { useState } from "react";
-import { toYYYYMMDD } from "@/utils/dateUtils";
+import { useMemo, useState } from "react";
+import { getDaysInMonth, toYYYYMMDD } from "@/utils/dateUtils";
+import { range } from "@/utils/number";
 import { Button } from "../Button";
 import { Wheel } from "./Wheel";
-
-/**
- * @TODO 데이터 변경 필요
- */
-
-const YEAR = [2024, 2025];
-const MONTH = new Array(12).fill(0).map((_, i) => i + 1);
-const DAY = new Array(30).fill(0).map((_, i) => i + 1);
 
 type DateType = {
   year: number;
   month: number;
   day: number;
 };
+
 export interface DatePickerProps {
   defaultDate?: Date;
   onChangeDate?: (date: string) => void;
+  minDate?: Date;
+  maxDate?: Date;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const DatePicker = ({ defaultDate = new Date(), onChangeDate }: DatePickerProps) => {
+export const DatePicker = ({
+  defaultDate = new Date(),
+  onChangeDate,
+  minDate = new Date(),
+  maxDate = new Date(new Date().getFullYear() + 1, new Date().getMonth(), new Date().getDate()),
+}: DatePickerProps) => {
   const [selectedDate, setSelectedDate] = useState({
     year: defaultDate.getFullYear(),
-    month: defaultDate.getMonth(),
+    month: defaultDate.getMonth() + 1,
     day: defaultDate.getDay(),
   });
 
@@ -37,6 +37,51 @@ export const DatePicker = ({ defaultDate = new Date(), onChangeDate }: DatePicke
     const YYYYMMDD = toYYYYMMDD(new Date(selectedDate.year, selectedDate.month, selectedDate.day));
     onChangeDate?.(YYYYMMDD);
   };
+
+  const min = {
+    year: minDate.getFullYear(),
+    month: minDate.getMonth() + 1,
+    day: minDate.getDate(),
+  };
+
+  const max = {
+    year: maxDate.getFullYear(),
+    month: maxDate.getMonth() + 1,
+    day: maxDate.getDate(),
+  };
+
+  const YEAR = useMemo(() => range(min.year, max.year), [min.year, max.year]);
+
+  const MONTH = useMemo(() => {
+    if (min.year === max.year) {
+      return range(min.month, max.month);
+    } else if (minDate.getFullYear() === selectedDate.year) {
+      return range(min.month, 12);
+    } else if (maxDate.getFullYear() === selectedDate.year) {
+      return range(1, max.month);
+    }
+    return range(1, 12);
+  }, [max.month, max.year, maxDate, min.month, min.year, minDate, selectedDate.year]);
+
+  const DAY = useMemo(() => {
+    if (min.year === max.year && min.month === max.month) {
+      return range(min.day, max.day);
+    } else if (min.year === selectedDate.year && min.month === selectedDate.month) {
+      return range(min.day, getDaysInMonth(selectedDate.year, selectedDate.month));
+    } else if (max.year === selectedDate.year && max.month === selectedDate.month) {
+      return range(1, max.day);
+    }
+    return range(1, getDaysInMonth(selectedDate.year, selectedDate.month));
+  }, [
+    min.year,
+    min.month,
+    min.day,
+    max.year,
+    max.month,
+    max.day,
+    selectedDate.year,
+    selectedDate.month,
+  ]);
 
   return (
     <div className="absolute inset-x-0 bottom-0 z-overlay rounded-t-xl bg-white py-5 text-2xl">

--- a/components/DatePicker/DatePicker.tsx
+++ b/components/DatePicker/DatePicker.tsx
@@ -39,8 +39,8 @@ export const DatePicker = ({ defaultDate = new Date(), onChangeDate }: DatePicke
   };
 
   return (
-    <div className="absolute inset-x-0 bottom-0 z-overlay rounded-t-xl bg-white py-5">
-      <div className="flex h-60 w-full">
+    <div className="absolute inset-x-0 bottom-0 z-overlay rounded-t-xl bg-white py-5 text-2xl">
+      <div className="flex h-60 w-full px-5">
         <Wheel //
           items={YEAR}
           onChangeItemIndex={(index) => handleChangeItem("year", YEAR[index])}
@@ -54,7 +54,9 @@ export const DatePicker = ({ defaultDate = new Date(), onChangeDate }: DatePicke
           onChangeItemIndex={(index) => handleChangeItem("day", DAY[index])}
         />
       </div>
-      <Button onClick={handleChangeDate}>선택</Button>
+      <div className="px-5 pb-4 pt-6">
+        <Button onClick={handleChangeDate}>선택</Button>
+      </div>
     </div>
   );
 };

--- a/components/DatePicker/DatePicker.tsx
+++ b/components/DatePicker/DatePicker.tsx
@@ -89,14 +89,17 @@ export const DatePicker = ({
         <Wheel //
           items={YEAR}
           onChangeItemIndex={(index) => handleChangeItem("year", YEAR[index])}
+          initialIndex={selectedDate.year - min.year}
         />
         <Wheel
           items={MONTH}
           onChangeItemIndex={(index) => handleChangeItem("month", MONTH[index])}
+          initialIndex={selectedDate.month - 1}
         />
         <Wheel //
           items={DAY}
           onChangeItemIndex={(index) => handleChangeItem("day", DAY[index])}
+          initialIndex={selectedDate.day - 1}
         />
       </div>
       <div className="px-5 pb-4 pt-6">

--- a/components/DatePicker/DatePicker.tsx
+++ b/components/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { getDaysInMonth, toYYYYMMDD } from "@/utils/dateUtils";
 import { range } from "@/utils/number";
 import { Button } from "../Button";
@@ -83,23 +83,29 @@ export const DatePicker = ({
     selectedDate.month,
   ]);
 
+  const initalIndex = useRef({
+    year: selectedDate.year - min.year,
+    month: selectedDate.month - 1,
+    day: selectedDate.day - 1,
+  });
+
   return (
     <div className="absolute inset-x-0 bottom-0 z-overlay rounded-t-xl bg-white py-5 text-2xl">
       <div className="flex h-60 w-full px-5">
         <Wheel //
           items={YEAR}
           onChangeItemIndex={(index) => handleChangeItem("year", YEAR[index])}
-          initialIndex={selectedDate.year - min.year}
+          initialIndex={initalIndex.current.year}
         />
         <Wheel
           items={MONTH}
           onChangeItemIndex={(index) => handleChangeItem("month", MONTH[index])}
-          initialIndex={selectedDate.month - 1}
+          initialIndex={initalIndex.current.month}
         />
         <Wheel //
           items={DAY}
           onChangeItemIndex={(index) => handleChangeItem("day", DAY[index])}
-          initialIndex={selectedDate.day - 1}
+          initialIndex={initalIndex.current.day}
         />
       </div>
       <div className="px-5 pb-4 pt-6">

--- a/components/DatePicker/Wheel.css
+++ b/components/DatePicker/Wheel.css
@@ -9,7 +9,7 @@
   justify-content: center;
   perspective: 1000px;
   transform-style: preserve-3d;
-  height: 16%;
+  height: 50px;
   width: 100%;
 }
 
@@ -30,6 +30,14 @@
   height: 42%;
   width: 100%;
   z-index: 5;
+}
+
+.wheel__shadow-top {
+  border-bottom: 1px solid #d9d9d9;
+}
+
+.wheel__shadow-bottom {
+  border-top: 1px solid #d9d9d9;
 }
 
 .wheel__shadow-bottom {

--- a/components/DatePicker/Wheel.tsx
+++ b/components/DatePicker/Wheel.tsx
@@ -3,7 +3,7 @@ import "./Wheel.css";
 import { TrackDetails, useKeenSlider } from "keen-slider/react";
 import { useEffect, useRef, useState } from "react";
 
-const wheelSize = 20;
+const wheelSize = 15;
 const slideDgree = 360 / wheelSize;
 
 interface WheelProps<T> {
@@ -80,7 +80,7 @@ export const Wheel = <T extends string | number>({
       <div className="wheel__inner">
         <div className="wheel__slides">
           {getSlideStyles().map((style, idx) => (
-            <div className="wheel__slide subheading" style={style} key={idx}>
+            <div className="wheel__slide" style={style} key={idx}>
               <span>{items[idx]}</span>
             </div>
           ))}

--- a/components/DatePicker/Wheel.tsx
+++ b/components/DatePicker/Wheel.tsx
@@ -10,12 +10,14 @@ interface WheelProps<T> {
   items: T[];
   onChangeItemIndex?: (index: number) => void;
   loop?: boolean;
+  initialIndex?: number;
 }
 
 export const Wheel = <T extends string | number>({
   items,
   onChangeItemIndex,
   loop,
+  initialIndex = 0,
 }: WheelProps<T>) => {
   const size = useRef(0);
   const slidesPerView = loop ? 9 : 1;
@@ -27,6 +29,7 @@ export const Wheel = <T extends string | number>({
       origin: loop ? "center" : "auto",
       perView: slidesPerView,
     },
+    initial: initialIndex,
     vertical: true,
     loop,
     rubberband: !loop,
@@ -62,7 +65,7 @@ export const Wheel = <T extends string | number>({
     const offset = loop ? (1 - 1 / slidesPerView) / 2 : 0;
 
     const styles = [];
-    for (let i = 0; i < items.length; i++) {
+    for (let i = 0; i < sliderState.length + 1; i++) {
       const distance = (sliderState.slides[i].distance - offset) * slidesPerView;
       const rotate = Math.abs(distance) > wheelSize / 2 ? 180 : distance * (360 / wheelSize) * -1;
       const style = {

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -5,3 +5,7 @@ export const toYYYYMMDD = (date: Date) => {
 
   return `${year}-${month}-${day}`;
 };
+
+export const getDaysInMonth = (year: number, month: number) => {
+  return new Date(year, month, 0).getDate();
+};

--- a/utils/number.ts
+++ b/utils/number.ts
@@ -1,0 +1,3 @@
+export const range = (start: number, end: number, step = 1) => {
+  return Array.from({ length: (end - start) / step + 1 }, (_, i) => start + i * step);
+};


### PR DESCRIPTION
- defaultDate props로 받은 날짜를 초기 날짜로 보여주도록 함
- 커피챗 시간 선택 범위 제한 정책을 반영하기 위해 minDate, maxDate를 통해 date range를 설정할 수 있도록 함
- resolved #66 