### PR TITLE
refactor: 토큰 처리 로직 변경

### DIFF
--- a/apis/auth/hooks/useOauthLogin.ts
+++ b/apis/auth/hooks/useOauthLogin.ts
@@ -1,6 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
-import { isAxiosError } from "axios";
+import { AxiosHeaders, isAxiosError } from "axios";
 import { useRouter } from "@/libs/navigation";
+import { authCookie } from "@/stores/auth";
 import { useProviderStore } from "@/stores/provider";
 import { useUserStore } from "@/stores/user";
 import { authApi } from "../api";
@@ -13,7 +14,15 @@ export const useOauthLogin = () => {
 
   return useMutation({
     mutationFn: authApi.oauthLogin,
-    onSuccess: () => {
+    onSuccess: (response) => {
+      if (response.headers instanceof AxiosHeaders) {
+        const accessToken = response.headers.get("Authorization");
+
+        if (accessToken && typeof accessToken === "string") {
+          authCookie.set(accessToken);
+        }
+      }
+
       router.replace("/");
     },
     onError: (error) => {

--- a/apis/auth/hooks/useOauthLogout.ts
+++ b/apis/auth/hooks/useOauthLogout.ts
@@ -1,17 +1,16 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@/libs/navigation";
-import { useAuthStore } from "@/stores/auth";
+import { authCookie } from "@/stores/auth";
 import { authApi } from "../api";
 
 export const useOauthLogout = () => {
   const router = useRouter();
-  const clear = useAuthStore((state) => state.clear);
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: authApi.oauthLogout,
     onSuccess: () => {
-      clear();
+      authCookie.clear();
       queryClient.removeQueries();
       router.push("/login");
     },

--- a/apis/axios.ts
+++ b/apis/axios.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosHeaders } from "axios";
-import { useAuthStore } from "@/stores/auth";
+import { authCookie } from "@/stores/auth";
 import { authApi } from "./auth/api";
 
 export const apiInstance = axios.create({
@@ -8,7 +8,7 @@ export const apiInstance = axios.create({
 });
 
 apiInstance.interceptors.request.use((config) => {
-  const { accessToken } = useAuthStore.getState();
+  const accessToken = authCookie.get();
 
   if (accessToken) {
     config.headers.setAuthorization(accessToken);
@@ -23,7 +23,7 @@ apiInstance.interceptors.response.use(
       const accessToken = response.headers.get("Authorization");
 
       if (accessToken && typeof accessToken === "string") {
-        useAuthStore.setState({ accessToken });
+        authCookie.set(accessToken);
       }
     }
     return response;
@@ -34,7 +34,7 @@ apiInstance.interceptors.response.use(
       error.response.data.errorCode === "AUTH_002" &&
       error.config.url !== "/api/token/reissue"
     ) {
-      useAuthStore.getState().clear();
+      authCookie.clear();
 
       try {
         await authApi.reissueToken();

--- a/apis/user/hooks/useSignout.ts
+++ b/apis/user/hooks/useSignout.ts
@@ -1,17 +1,16 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@/libs/navigation";
-import { useAuthStore } from "@/stores/auth";
+import { authCookie } from "@/stores/auth";
 import { userApi } from "../api";
 
 export const useSignout = () => {
   const router = useRouter();
-  const clear = useAuthStore((state) => state.clear);
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: userApi.signout,
     onSuccess: () => {
-      clear();
+      authCookie.clear();
       queryClient.removeQueries();
       router.push("/login");
     },

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { isAxiosError } from "axios";
-import { setCookie } from "cookies-next";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
@@ -9,7 +8,7 @@ import { apiInstance } from "@/apis/axios";
 import { Button } from "@/components/Button";
 import { FormControl, FormLabel } from "@/components/FormControl";
 import { Input } from "@/components/Input";
-import { useAuthStore } from "@/stores/auth";
+import { authCookie } from "@/stores/auth";
 
 interface LoginForm {
   email: string;
@@ -28,14 +27,12 @@ const Page = () => {
     },
   });
   const [errorMessage, setErrorMessage] = useState("");
-  const { setAccessToken } = useAuthStore();
 
   const login = async (data: LoginForm) => {
     try {
       const response = await apiInstance.post("/api/auth/dummy/login", data);
-      const { accessToken, refreshToken } = response.data.token;
-      setCookie("refresh_token", refreshToken);
-      setAccessToken(accessToken);
+      const { accessToken } = response.data.token;
+      authCookie.set(`Bearer ${accessToken}`);
       router.push("/");
     } catch (e) {
       if (isAxiosError(e) && e.response) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,7 +7,7 @@ export function middleware(request: NextRequest) {
   /** authentication */
   const { pathname } = request.nextUrl;
 
-  const isAuthenticated = request.cookies.get("refresh_token");
+  const isAuthenticated = request.cookies.get("access_token");
 
   if (!isAuthenticated && PRIVATE_PATH.some((path) => pathname.startsWith(path))) {
     return NextResponse.redirect(new URL("/login", request.url));

--- a/stores/auth.ts
+++ b/stores/auth.ts
@@ -1,18 +1,22 @@
-import { create } from "zustand";
-import { devtools } from "zustand/middleware";
+import { deleteCookie, getCookie, setCookie } from "cookies-next";
 
-interface AuthState {
-  accessToken?: string;
-  setAccessToken: (accessToken: string) => void;
-  clear: () => void;
-}
+export const authCookie = {
+  cookieKey: "access_token",
+  maxAge: 60 * 60 * 2 + 60,
 
-export const useAuthStore = create<AuthState>()(
-  devtools((set) => ({
-    setAccessToken: (accessToken) =>
-      set(() => ({
-        accessToken,
-      })),
-    clear: () => set(() => ({ accessToken: undefined })),
-  }))
-);
+  get() {
+    const accessToken = getCookie(this.cookieKey);
+
+    return accessToken;
+  },
+
+  set(accessToken: string) {
+    setCookie(this.cookieKey, accessToken, {
+      maxAge: this.maxAge,
+    });
+  },
+
+  clear() {
+    deleteCookie(this.cookieKey);
+  },
+};


### PR DESCRIPTION
- 토큰 보관 방식 변경
- access token을 통해 로그인 유무 판단하도록 수정
- 응답 헤더의 토큰 값을 처리하는 로직을 interceptor가 아닌 각각의 사용처(로그인 / 토큰 재발급)로 이동한다. 특정 상황에 한정되는 로직을 interceptor단에서 전역적으로 수행하지 않도록