### PR TITLE
fix: 무효화된 커피챗 상세 조회 쿼리의 refetch 시점 조정

### DIFF
--- a/apis/coffeechat-status/hooks/useUpdateCoffeeChatApplyToApprove.ts
+++ b/apis/coffeechat-status/hooks/useUpdateCoffeeChatApplyToApprove.ts
@@ -7,7 +7,7 @@ export const useUpdateCoffeeChatApplyToApprove = () => {
   return useMutation({
     mutationFn: coffeeChatStatusApi.patchCoffeeChatApplyToApprove,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["coffeeChat"] });
+      queryClient.invalidateQueries({ queryKey: ["coffeeChat"], refetchType: "none" });
     },
   });
 };

--- a/apis/coffeechat-status/hooks/useUpdateCoffeeChatApplyToReject.ts
+++ b/apis/coffeechat-status/hooks/useUpdateCoffeeChatApplyToReject.ts
@@ -7,7 +7,7 @@ export const useUpdateCoffeeChatApplyToReject = () => {
   return useMutation({
     mutationFn: coffeeChatStatusApi.patchCoffeeChatApplyToReject,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["coffeeChat"] });
+      queryClient.invalidateQueries({ queryKey: ["coffeeChat"], refetchType: "none" });
     },
   });
 };

--- a/apis/coffeechat-status/hooks/useUpdateCoffeeChatMenteeApproved.ts
+++ b/apis/coffeechat-status/hooks/useUpdateCoffeeChatMenteeApproved.ts
@@ -7,7 +7,7 @@ export const useUpdateCoffeeChatMenteeApproved = () => {
   return useMutation({
     mutationFn: coffeeChatStatusApi.patchCoffeeChatMenteeApproved,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["coffeeChat"] });
+      queryClient.invalidateQueries({ queryKey: ["coffeeChat"], refetchType: "none" });
     },
   });
 };

--- a/apis/coffeechat-status/hooks/useUpdateCoffeeChatMenteeRejected.ts
+++ b/apis/coffeechat-status/hooks/useUpdateCoffeeChatMenteeRejected.ts
@@ -7,7 +7,7 @@ export const useUpdateCoffeeChatMenteeRejected = () => {
   return useMutation({
     mutationFn: coffeeChatStatusApi.patchCoffeeChatMenteeRejected,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["coffeeChat"] });
+      queryClient.invalidateQueries({ queryKey: ["coffeeChat"], refetchType: "none" });
     },
   });
 };

--- a/apis/coffeechat-status/hooks/useUpdateCoffeeChatMentorApproved.ts
+++ b/apis/coffeechat-status/hooks/useUpdateCoffeeChatMentorApproved.ts
@@ -7,7 +7,7 @@ export const useUpdateCoffeeChatMentorApproved = () => {
   return useMutation({
     mutationFn: coffeeChatStatusApi.patchCoffeeChatMentorApproved,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["coffeeChat"] });
+      queryClient.invalidateQueries({ queryKey: ["coffeeChat"], refetchType: "none" });
     },
   });
 };

--- a/apis/coffeechat-status/hooks/useUpdateCoffeeChatMentorRejected.ts
+++ b/apis/coffeechat-status/hooks/useUpdateCoffeeChatMentorRejected.ts
@@ -7,7 +7,7 @@ export const useUpdateCoffeeChatMentorRejected = () => {
   return useMutation({
     mutationFn: coffeeChatStatusApi.patchCoffeeChatMentorRejected,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["coffeeChat"] });
+      queryClient.invalidateQueries({ queryKey: ["coffeeChat"], refetchType: "none" });
     },
   });
 };

--- a/apis/coffeechat-status/hooks/useUpdateCoffeeChatToCancel.ts
+++ b/apis/coffeechat-status/hooks/useUpdateCoffeeChatToCancel.ts
@@ -1,8 +1,13 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { coffeeChatStatusApi } from "../api";
 
 export const useUpdateCoffeeChatToCancel = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: coffeeChatStatusApi.patchCoffeeChatToCancel,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["coffeeChat"], refetchType: "none" });
+    },
   });
 };

--- a/apis/coffeechat/hooks/useGetCoffeeChatById.ts
+++ b/apis/coffeechat/hooks/useGetCoffeeChatById.ts
@@ -5,6 +5,7 @@ const useGetCoffeeChatById = (id: number) => {
   return useQuery({
     queryKey: ["coffeeChat", id],
     queryFn: () => coffeeChatApi.getCoffeeChatById(id),
+    refetchOnWindowFocus: false,
   });
 };
 

--- a/app/[locale]/(main)/coffeechat/[id]/page.tsx
+++ b/app/[locale]/(main)/coffeechat/[id]/page.tsx
@@ -11,10 +11,10 @@ const Page = ({ params }: { params: { id: string } }) => {
   const coffeeChatId = Number(params.id);
   const router = useRouter();
   const { data: me } = useGetMe();
-  const { data: coffeeChatDetail } = useGetCoffeeChatById(coffeeChatId);
+  const { data: coffeeChatDetail, isFetching } = useGetCoffeeChatById(coffeeChatId);
   const { coffeeChat } = coffeeChatDetail ?? {};
 
-  if (!me || !coffeeChat) return;
+  if (!me || !coffeeChat || isFetching) return;
 
   const CoffeeChatDetail = {
     MentorView: MentorView[coffeeChat.status],


### PR DESCRIPTION
- fixed #139 
- 쿼리 무효화로 인해 커피챗 상세 조회 쿼리가 바로 refetch되고 변경된 status의 화면으로 바뀌는 것이 원인으로 작용
- active 상태의 경우 refetch를 수행하지 않도록 refetchType 옵션 추가
- +다시 마운트되는 경우 stale한 데이터가 보여지지 않도록 isFetching 옵션 사용